### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 permalink: /:title
 exclude: [".ruby-version", "Gemfile", "Gemfile.lock", "README.md", "CONTRIBUTING.md"]
 markdown: kramdown
-highlighter: pygments
+highlighter: rouge
 
 # Title
 name: PROJECT NAME


### PR DESCRIPTION
To fix

```
The page build completed successfully, but returned the following warning:

You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.
```